### PR TITLE
Fix circular dependency detection and self-dependency check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [3.1.4] - 2026-02-22
+
+### Fixed
+
+- Fixed circular dependency detection — all circular dependencies now throw `CircularDependencyError` instead of silently stack overflowing
+- Fixed self-dependency check that was unreachable due to comparing abstract class against concrete class
+
+### Added
+
+- New `CircularDependencyError` exported error class
+
 ## [3.1.3] - 2026-02-09
 
 ### Security
@@ -158,6 +169,7 @@
 
 Initial release.
 
+[3.1.4]: https://github.com/shellicar/core-di/releases/tag/3.1.4
 [3.1.3]: https://github.com/shellicar/core-di/releases/tag/3.1.3
 [3.1.2]: https://github.com/shellicar/core-di/releases/tag/3.1.2
 [3.1.1]: https://github.com/shellicar/core-di/releases/tag/3.1.1

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 * 🎨 Decorator-based property injection
 * 🔄 Flexible lifetime management
 * 📦 Service modules for organization
+* 🔍 Circular dependency detection at resolution time
 * 🚨 Clear error messages with dependency chain tracking
 
 ## Installation & Quick Start

--- a/TODO.md
+++ b/TODO.md
@@ -16,20 +16,9 @@ Each item is scored 1-5 on two axes, then combined:
 
 ## Items
 
-### 1. Circular dependency unit tests — Priority: 5
+### ~~1. Circular dependency detection — Done (v3.1.4)~~
 
-| Value | Cost | Priority |
-|-------|------|----------|
-| 5     | 1    | 5        |
-
-Add unit tests to verify and document current circular reference behaviour across all lifetimes. No code changes needed — just tests that pin down existing behaviour.
-
-**Current behaviour:**
-- **Self-dependency** (A→A): Detected, throws `SelfDependencyError`
-- **Indirect cycles** (A→B→A) with `Resolve`/`Singleton`/`Scoped` lifetimes: `ResolutionContext` cache returns the partially-constructed instance, preventing infinite recursion (but the dependent gets an incomplete instance)
-- **Indirect cycles with `Transient` lifetime**: No protection — will stack overflow, as `Transient` has no cache map
-
-**Action:** Write tests, confirm behaviour, then decide if any of it needs fixing.
+Fixed in v3.1.4. All circular dependencies now throw `CircularDependencyError`. Self-dependency check fixed to correctly throw `SelfDependencyError`. 7 tests added covering self-dependency, 2-node cycles, and 3-node cycles across all lifetimes.
 
 ### 2. Routine dependency updates — Priority: 5
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,80 @@
+# TODO
+
+Future work, ideas, and potential improvements for `@shellicar/core-di`.
+
+## Background
+
+This library started as a replacement for `inversify` (which is stuck on TypeScript v4) and is modelled after `Microsoft.Extensions.DependencyInjection`. It uses property injection via `@dependsOn` decorators and abstract classes as runtime-resolvable interfaces.
+
+## Priority Key
+
+Each item is scored 1-5 on two axes, then combined:
+
+- **Value** = Urgency x Importance (how much it matters and how soon)
+- **Cost** = Effort to implement (1 = trivial, 5 = major undertaking)
+- **Priority** = Value / Cost (higher is better)
+
+## Items
+
+### 1. Circular dependency unit tests — Priority: 5
+
+| Value | Cost | Priority |
+|-------|------|----------|
+| 5     | 1    | 5        |
+
+Add unit tests to verify and document current circular reference behaviour across all lifetimes. No code changes needed — just tests that pin down existing behaviour.
+
+**Current behaviour:**
+- **Self-dependency** (A→A): Detected, throws `SelfDependencyError`
+- **Indirect cycles** (A→B→A) with `Resolve`/`Singleton`/`Scoped` lifetimes: `ResolutionContext` cache returns the partially-constructed instance, preventing infinite recursion (but the dependent gets an incomplete instance)
+- **Indirect cycles with `Transient` lifetime**: No protection — will stack overflow, as `Transient` has no cache map
+
+**Action:** Write tests, confirm behaviour, then decide if any of it needs fixing.
+
+### 2. Routine dependency updates — Priority: 5
+
+| Value | Cost | Priority |
+|-------|------|----------|
+| 5     | 1    | 5        |
+
+- `syncpack` 13→14 (resolves minimatch ReDoS CVE, dev-only)
+- `@biomejs/biome`, `turbo`, `@types/node`, `npm-check-updates`, `lefthook` — minor/patch updates
+
+Pure hygiene. Clears the audit CVE. No design decisions.
+
+### 3. Singleton disposal verification — Priority: 4
+
+| Value | Cost | Priority |
+|-------|------|----------|
+| 4     | 1    | 4        |
+
+Currently `Transient` and `Scoped` `IDisposable` instances are tracked and disposed when the provider/scope is disposed. Singleton instances are **not** disposed (see `ServiceProvider.ts:105`). This mirrors MS DI behaviour where singleton disposal is the responsibility of the root container's disposal. Write a test or two to confirm, then document the expected lifecycle.
+
+### 4. Separate resolution graph from resolution — Priority: 1.5
+
+| Value | Cost | Priority |
+|-------|------|----------|
+| 3     | 4    | ~1.5     |
+
+Currently `ResolutionContext` tracks resolved instances per-lifetime, but the dependency graph is walked implicitly during resolution. Separating graph construction from instance creation would enable:
+
+- Better circular dependency error messages (detect cycles before attempting construction)
+- Graph validation at `buildProvider()` time rather than at first `resolve()` call
+- Potential for graph visualisation/debugging tools
+- Clearer separation of concerns
+
+Significant architectural change. Would likely require a major version bump. Worth doing when investing in the next evolution of the library, not as a maintenance task.
+
+### 5. Async resolution — Priority: 0.5
+
+| Value | Cost | Priority |
+|-------|------|----------|
+| 2     | 5    | ~0.5     |
+
+MS DI (`Microsoft.Extensions.DependencyInjection`) does not support async resolution, and no clean pattern has emerged for this. Known approaches and their tradeoffs:
+
+1. **Async factory functions** (`resolveAsync`) — Works, but splits the API into sync/async paths. Every consumer must decide which to call.
+2. **Two-phase initialisation** — Resolve synchronously, then call an `initAsync()` method. Keeps DI simple but pushes async concerns to consumers.
+3. **Startup/initialisation hooks** — Register async initialisers separately, run them after the graph is built. Clean separation but adds ceremony.
+
+None are particularly satisfying. Park until a concrete use case forces the issue or a good pattern emerges.

--- a/TODO.md
+++ b/TODO.md
@@ -20,16 +20,9 @@ Each item is scored 1-5 on two axes, then combined:
 
 Fixed in v3.1.4. All circular dependencies now throw `CircularDependencyError`. Self-dependency check fixed to correctly throw `SelfDependencyError`. 7 tests added covering self-dependency, 2-node cycles, and 3-node cycles across all lifetimes.
 
-### 2. Routine dependency updates — Priority: 5
+### ~~2. Routine dependency updates — Done~~
 
-| Value | Cost | Priority |
-|-------|------|----------|
-| 5     | 1    | 5        |
-
-- `syncpack` 13→14 (resolves minimatch ReDoS CVE, dev-only)
-- `@biomejs/biome`, `turbo`, `@types/node`, `npm-check-updates`, `lefthook` — minor/patch updates
-
-Pure hygiene. Clears the audit CVE. No design decisions.
+Syncpack 13→14 completed in PR #20, resolving minimatch ReDoS CVE (CVE-2026-26996). Remaining minor/patch updates (`@biomejs/biome`, `turbo`, `@types/node`, `npm-check-updates`, `lefthook`) can be done in a future maintenance pass.
 
 ### 3. Singleton disposal verification — Priority: 4
 

--- a/examples/readme/src/circular-dependency.ts
+++ b/examples/readme/src/circular-dependency.ts
@@ -1,0 +1,78 @@
+import { CircularDependencyError, createServiceCollection, dependsOn, SelfDependencyError, ServiceError } from '@shellicar/core-di';
+
+// Self-dependency: A depends on itself
+abstract class ISelfDep {
+  abstract value(): string;
+}
+class SelfDep implements ISelfDep {
+  @dependsOn(ISelfDep) private readonly self!: ISelfDep;
+  value(): string {
+    return 'self';
+  }
+}
+
+// Circular dependency: A → B → A
+abstract class IServiceA {
+  abstract value(): string;
+}
+abstract class IServiceB {
+  abstract value(): string;
+}
+class ServiceA implements IServiceA {
+  @dependsOn(IServiceB) private readonly b!: IServiceB;
+  value(): string {
+    return 'a';
+  }
+}
+class ServiceB implements IServiceB {
+  @dependsOn(IServiceA) private readonly a!: IServiceA;
+  value(): string {
+    return 'b';
+  }
+}
+
+// Self-dependency throws SelfDependencyError
+{
+  const services = createServiceCollection();
+  services.register(ISelfDep).to(SelfDep);
+  const provider = services.buildProvider();
+  try {
+    provider.resolve(ISelfDep);
+  } catch (err) {
+    console.error(err);
+    if (err instanceof SelfDependencyError) {
+      console.log('Caught self-dependency:', err.message);
+    }
+  }
+}
+
+// Circular dependency throws CircularDependencyError
+{
+  const services = createServiceCollection();
+  services.register(IServiceA).to(ServiceA);
+  services.register(IServiceB).to(ServiceB);
+  const provider = services.buildProvider();
+  try {
+    provider.resolve(IServiceA);
+  } catch (err) {
+    console.error(err);
+    if (err instanceof CircularDependencyError) {
+      console.log('Caught circular dependency:', err.message);
+    }
+  }
+}
+
+// Both errors extend ServiceError for catch-all handling
+{
+  const services = createServiceCollection();
+  services.register(IServiceA).to(ServiceA);
+  services.register(IServiceB).to(ServiceB);
+  const provider = services.buildProvider();
+  try {
+    provider.resolve(IServiceA);
+  } catch (err) {
+    if (err instanceof ServiceError) {
+      console.log('Caught service error:', err.name, err.message);
+    }
+  }
+}

--- a/examples/readme/src/index.ts
+++ b/examples/readme/src/index.ts
@@ -26,3 +26,5 @@ import './override-lifetime';
 import './logging-options';
 // * Service modules
 import './service-modules';
+// * Circular dependency detection
+import './circular-dependency';

--- a/packages/core-di/package.json
+++ b/packages/core-di/package.json
@@ -53,6 +53,7 @@
     "@shellicar/build-clean": "^1.2.2",
     "@tsconfig/node20": "^20.1.9",
     "@types/node": "^25.2.2",
+    "@vitest/coverage-v8": "^4.0.18",
     "terser": "^5.46.0",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",

--- a/packages/core-di/package.json
+++ b/packages/core-di/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shellicar/core-di",
   "private": false,
-  "version": "3.1.3",
+  "version": "3.1.4",
   "type": "module",
   "license": "MIT",
   "author": "Stephen Hellicar",

--- a/packages/core-di/src/errors.ts
+++ b/packages/core-di/src/errors.ts
@@ -46,6 +46,14 @@ export class SelfDependencyError extends ServiceError {
   }
 }
 
+export class CircularDependencyError extends ServiceError {
+  name = 'CircularDependencyError';
+  constructor(identifier: ServiceIdentifier<object>) {
+    super(`Circular dependency detected while resolving: ${identifier.name}`);
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
 export class ScopedSingletonRegistrationError extends ServiceError {
   name = 'ScopedSingletonRegistrationError';
   constructor() {

--- a/packages/core-di/src/index.ts
+++ b/packages/core-di/src/index.ts
@@ -2,7 +2,7 @@ export { createServiceCollection } from './createServiceCollection';
 export { DefaultServiceCollectionOptions } from './defaults';
 export { dependsOn } from './dependsOn';
 export { Lifetime, LogLevel, ResolveMultipleMode } from './enums';
-export { InvalidImplementationError, InvalidServiceIdentifierError, MultipleRegistrationError, ScopedSingletonRegistrationError, SelfDependencyError, ServiceCreationError, ServiceError, UnregisteredServiceError } from './errors';
+export { CircularDependencyError, InvalidImplementationError, InvalidServiceIdentifierError, MultipleRegistrationError, ScopedSingletonRegistrationError, SelfDependencyError, ServiceCreationError, ServiceError, UnregisteredServiceError } from './errors';
 export { IDisposable, ILifetimeBuilder, IResolutionScope, IScopedProvider, IServiceBuilder, IServiceCollection, IServiceModule, IServiceProvider } from './interfaces';
 export { ILogger } from './logger';
 export type { AbstractNewable, InstanceFactory, MetadataType, Newable, ServiceCollectionOptions, ServiceDescriptor, ServiceIdentifier, ServiceImplementation, ServiceModuleType, ServiceRegistration, SourceType } from './types';

--- a/packages/core-di/src/private/ResolutionContext.ts
+++ b/packages/core-di/src/private/ResolutionContext.ts
@@ -9,6 +9,19 @@ export class ResolutionContext {
   ) {}
 
   private readonly transient: RegistrationMap = createRegistrationMap();
+  private readonly resolving = new Set<ServiceRegistration<SourceType>>();
+
+  public markResolving<T extends SourceType>(implementation: ServiceRegistration<T>): boolean {
+    if (this.resolving.has(implementation)) {
+      return false;
+    }
+    this.resolving.add(implementation);
+    return true;
+  }
+
+  public unmarkResolving<T extends SourceType>(implementation: ServiceRegistration<T>): void {
+    this.resolving.delete(implementation);
+  }
 
   public getFromLifetime<T extends SourceType>(implementation: ServiceRegistration<T>, lifetime: Lifetime): T | null {
     const map = this.getMapForLifetime(lifetime);

--- a/packages/core-di/test/circular-dependency.spec.ts
+++ b/packages/core-di/test/circular-dependency.spec.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createServiceCollection, dependsOn, SelfDependencyError } from '../src';
-import { CircularDependencyError } from '../src/errors';
+import { CircularDependencyError, createServiceCollection, dependsOn, SelfDependencyError } from '../src';
 
 // Self-dependency: A depends on A (via interface)
 abstract class ISelfDependent {

--- a/packages/core-di/test/circular-dependency.spec.ts
+++ b/packages/core-di/test/circular-dependency.spec.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest';
+import { createServiceCollection, dependsOn, SelfDependencyError } from '../src';
+import { CircularDependencyError } from '../src/errors';
+
+// Self-dependency: A depends on A (via interface)
+abstract class ISelfDependent {
+  abstract value(): string;
+}
+
+class SelfDependent implements ISelfDependent {
+  @dependsOn(ISelfDependent) private readonly self!: ISelfDependent;
+
+  value(): string {
+    return 'self';
+  }
+}
+
+// Indirect cycle: A depends on B, B depends on A
+abstract class ICycleA {
+  abstract value(): string;
+}
+
+abstract class ICycleB {
+  abstract value(): string;
+}
+
+class CycleA implements ICycleA {
+  @dependsOn(ICycleB) private readonly b!: ICycleB;
+
+  value(): string {
+    return 'a';
+  }
+}
+
+class CycleB implements ICycleB {
+  @dependsOn(ICycleA) private readonly a!: ICycleA;
+
+  value(): string {
+    return 'b';
+  }
+}
+
+// Three-node cycle: A → B → C → A
+abstract class ICycle3A {
+  abstract value(): string;
+}
+
+abstract class ICycle3B {
+  abstract value(): string;
+}
+
+abstract class ICycle3C {
+  abstract value(): string;
+}
+
+class Cycle3A implements ICycle3A {
+  @dependsOn(ICycle3B) private readonly b!: ICycle3B;
+
+  value(): string {
+    return 'a';
+  }
+}
+
+class Cycle3B implements ICycle3B {
+  @dependsOn(ICycle3C) private readonly c!: ICycle3C;
+
+  value(): string {
+    return 'b';
+  }
+}
+
+class Cycle3C implements ICycle3C {
+  @dependsOn(ICycle3A) private readonly a!: ICycle3A;
+
+  value(): string {
+    return 'c';
+  }
+}
+
+describe('Circular dependency', () => {
+  describe('Self-dependency (A → A via interface)', () => {
+    it('throws SelfDependencyError', () => {
+      const services = createServiceCollection();
+      services.register(ISelfDependent).to(SelfDependent);
+      const provider = services.buildProvider();
+
+      const actual = () => provider.resolve(ISelfDependent);
+
+      expect(actual).toThrow(SelfDependencyError);
+    });
+  });
+
+  describe('Indirect cycle (A → B → A)', () => {
+    it('throws CircularDependencyError with Resolve lifetime', () => {
+      const services = createServiceCollection();
+      services.register(ICycleA).to(CycleA);
+      services.register(ICycleB).to(CycleB);
+      const provider = services.buildProvider();
+
+      const actual = () => provider.resolve(ICycleA);
+
+      expect(actual).toThrow(CircularDependencyError);
+    });
+
+    it('throws CircularDependencyError with Singleton lifetime', () => {
+      const services = createServiceCollection();
+      services.register(ICycleA).to(CycleA).singleton();
+      services.register(ICycleB).to(CycleB).singleton();
+      const provider = services.buildProvider();
+
+      const actual = () => provider.resolve(ICycleA);
+
+      expect(actual).toThrow(CircularDependencyError);
+    });
+
+    it('throws CircularDependencyError with Scoped lifetime', () => {
+      const services = createServiceCollection();
+      services.register(ICycleA).to(CycleA).scoped();
+      services.register(ICycleB).to(CycleB).scoped();
+      const provider = services.buildProvider();
+      const scoped = provider.createScope();
+
+      const actual = () => scoped.resolve(ICycleA);
+
+      expect(actual).toThrow(CircularDependencyError);
+    });
+
+    it('throws CircularDependencyError with Transient lifetime', () => {
+      const services = createServiceCollection();
+      services.register(ICycleA).to(CycleA).transient();
+      services.register(ICycleB).to(CycleB).transient();
+      const provider = services.buildProvider();
+
+      const actual = () => provider.resolve(ICycleA);
+
+      expect(actual).toThrow(CircularDependencyError);
+    });
+  });
+
+  describe('Three-node cycle (A → B → C → A)', () => {
+    it('throws CircularDependencyError with Resolve lifetime', () => {
+      const services = createServiceCollection();
+      services.register(ICycle3A).to(Cycle3A);
+      services.register(ICycle3B).to(Cycle3B);
+      services.register(ICycle3C).to(Cycle3C);
+      const provider = services.buildProvider();
+
+      const actual = () => provider.resolve(ICycle3A);
+
+      expect(actual).toThrow(CircularDependencyError);
+    });
+
+    it('throws CircularDependencyError with Transient lifetime', () => {
+      const services = createServiceCollection();
+      services.register(ICycle3A).to(Cycle3A).transient();
+      services.register(ICycle3B).to(Cycle3B).transient();
+      services.register(ICycle3C).to(Cycle3C).transient();
+      const provider = services.buildProvider();
+
+      const actual = () => provider.resolve(ICycle3A);
+
+      expect(actual).toThrow(CircularDependencyError);
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,6 +136,9 @@ importers:
       '@types/node':
         specifier: ^25.2.2
         version: 25.2.2
+      '@vitest/coverage-v8':
+        specifier: ^4.0.18
+        version: 4.0.18(vitest@4.0.18(@types/node@25.2.2)(terser@5.46.0)(tsx@4.21.0))
       terser:
         specifier: ^5.46.0
         version: 5.46.0
@@ -153,6 +156,27 @@ packages:
 
   '@abraham/reflection@0.13.0':
     resolution: {integrity: sha512-sQYhhraGPPRP6zoqpqpSaoYL+XY5KNmQCcoB3IuQh1z1aWmkHXcxwyTxRkTJ60L2aUjrbiqIqoYkrB/1c7kjQA==}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.0':
+    resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@biomejs/biome@2.3.14':
     resolution: {integrity: sha512-QMT6QviX0WqXJCaiqVMiBUCr5WRQ1iFSjvOLoTk6auKukJMvnMzWucXpwZB0e8F00/1/BsS9DzcKgWH+CLqVuA==}
@@ -554,6 +578,15 @@ packages:
   '@types/node@25.2.2':
     resolution: {integrity: sha512-BkmoP5/FhRYek5izySdkOneRyXYN35I860MFAGupTdebyE66uZaR+bXLHq8k4DirE5DwQi3NuhvRU1jqTVwUrQ==}
 
+  '@vitest/coverage-v8@4.0.18':
+    resolution: {integrity: sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==}
+    peerDependencies:
+      '@vitest/browser': 4.0.18
+      vitest: 4.0.18
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@4.0.18':
     resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
 
@@ -594,6 +627,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@0.3.11:
+    resolution: {integrity: sha512-Qya9fkoofMjCBNVdWINMjB5KZvkYfaO9/anwkWnjxibpWUxo5iHl2sOdP7/uAqaRuUYuoo8rDwnbaaKVFxoUvw==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -674,9 +710,31 @@ packages:
   get-tsconfig@4.13.6:
     resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
 
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   lefthook-darwin-arm64@2.1.0:
     resolution: {integrity: sha512-u2hjHLQXWSFfzO7ln2n/uEydSzfC9sc5cDC7tvKSuOdhvBwaJ0AQ7ZeuqqCQ4YfVIJfYOom1SVE9CBd10FVyig==}
@@ -745,6 +803,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.2:
+    resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
@@ -827,6 +892,11 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
@@ -855,6 +925,10 @@ packages:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
 
   syncpack-darwin-arm64@14.0.0:
     resolution: {integrity: sha512-mEcku9YkOHfM6JOxhq9McgeLvd4djsJvRwNONZXHeoJ6+yqC96DdxZwFjkw3e8Vn95wsxsrwY5ZjMExs5Gbacw==}
@@ -1097,6 +1171,21 @@ snapshots:
 
   '@abraham/reflection@0.13.0': {}
 
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/parser@7.29.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@bcoe/v8-coverage@1.0.2': {}
+
   '@biomejs/biome@2.3.14':
     optionalDependencies:
       '@biomejs/cli-darwin-arm64': 2.3.14
@@ -1335,6 +1424,20 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
+  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@25.2.2)(terser@5.46.0)(tsx@4.21.0))':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.0.18
+      ast-v8-to-istanbul: 0.3.11
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.2
+      obug: 2.1.1
+      std-env: 3.10.0
+      tinyrainbow: 3.0.3
+      vitest: 4.0.18(@types/node@25.2.2)(terser@5.46.0)(tsx@4.21.0)
+
   '@vitest/expect@4.0.18':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -1379,6 +1482,12 @@ snapshots:
   any-promise@1.3.0: {}
 
   assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@0.3.11:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   buffer-from@1.1.2: {}
 
@@ -1461,7 +1570,26 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  has-flag@4.0.0: {}
+
+  html-escaper@2.0.2: {}
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   joycon@3.1.1: {}
+
+  js-tokens@10.0.0: {}
 
   lefthook-darwin-arm64@2.1.0:
     optional: true
@@ -1515,6 +1643,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.2:
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
 
   mlly@1.8.0:
     dependencies:
@@ -1603,6 +1741,8 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.57.1
       fsevents: 2.3.3
 
+  semver@7.7.4: {}
+
   siginfo@2.0.0: {}
 
   source-map-js@1.2.1: {}
@@ -1629,6 +1769,10 @@ snapshots:
       pirates: 4.0.7
       tinyglobby: 0.2.15
       ts-interface-checker: 0.1.13
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
 
   syncpack-darwin-arm64@14.0.0:
     optional: true


### PR DESCRIPTION
## Summary

- Add circular dependency detection that throws `CircularDependencyError` instead of silently stack overflowing
- Fix self-dependency check that was unreachable due to comparing abstract class against concrete class
- Add `CircularDependencyError` exported error class
- Add 7 tests covering self-dependency, 2-node cycles, and 3-node cycles across all lifetimes

Co-Authored-By: Claude <noreply@anthropic.com>