### PR TITLE
Fix singleton disposal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.1.5] - 2026-02-23
+
+### Fixed
+
+- Fixed singleton disposal — root provider now disposes singleton `IDisposable` instances when disposed, matching MS DI behaviour
+- Added `IDisposable` implementation to `IServiceProvider` interface
+
 ## [3.1.4] - 2026-02-22
 
 ### Fixed
@@ -169,6 +176,7 @@
 
 Initial release.
 
+[3.1.5]: https://github.com/shellicar/core-di/releases/tag/3.1.5
 [3.1.4]: https://github.com/shellicar/core-di/releases/tag/3.1.4
 [3.1.3]: https://github.com/shellicar/core-di/releases/tag/3.1.3
 [3.1.2]: https://github.com/shellicar/core-di/releases/tag/3.1.2

--- a/TODO.md
+++ b/TODO.md
@@ -24,13 +24,9 @@ Fixed in v3.1.4. All circular dependencies now throw `CircularDependencyError`. 
 
 Syncpack 13→14 completed in PR #20, resolving minimatch ReDoS CVE (CVE-2026-26996). Remaining minor/patch updates (`@biomejs/biome`, `turbo`, `@types/node`, `npm-check-updates`, `lefthook`) can be done in a future maintenance pass.
 
-### 3. Singleton disposal verification — Priority: 4
+### ~~3. Singleton disposal — Done~~
 
-| Value | Cost | Priority |
-|-------|------|----------|
-| 4     | 1    | 4        |
-
-Currently `Transient` and `Scoped` `IDisposable` instances are tracked and disposed when the provider/scope is disposed. Singleton instances are **not** disposed (see `ServiceProvider.ts:105`). This mirrors MS DI behaviour where singleton disposal is the responsibility of the root container's disposal. Write a test or two to confirm, then document the expected lifecycle.
+Fixed: root provider now disposes singleton `IDisposable` instances when disposed, matching MS DI behaviour. Scoped providers still correctly skip singleton disposal. 4 tests added covering singleton, scoped, and transient disposal lifecycle.
 
 ### 4. Separate resolution graph from resolution — Priority: 1.5
 

--- a/packages/core-di/package.json
+++ b/packages/core-di/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shellicar/core-di",
   "private": false,
-  "version": "3.1.4",
+  "version": "3.1.5",
   "type": "module",
   "license": "MIT",
   "author": "Stephen Hellicar",

--- a/packages/core-di/src/interfaces.ts
+++ b/packages/core-di/src/interfaces.ts
@@ -35,9 +35,10 @@ export abstract class IScopedProvider extends IResolutionScope implements IDispo
   public abstract [Symbol.dispose](): void;
 }
 
-export abstract class IServiceProvider extends IResolutionScope {
+export abstract class IServiceProvider extends IResolutionScope implements IDisposable {
   public abstract readonly Services: IServiceCollection;
   public abstract createScope(): IScopedProvider;
+  public abstract [Symbol.dispose](): void;
 }
 
 export abstract class IServiceCollection {

--- a/packages/core-di/src/private/ServiceCollection.ts
+++ b/packages/core-di/src/private/ServiceCollection.ts
@@ -60,6 +60,6 @@ export class ServiceCollection implements IServiceCollection {
   }
 
   public buildProvider(): IServiceProvider {
-    return new ServiceProvider(this.logger, this.clone());
+    return ServiceProvider.createRoot(this.logger, this.clone());
   }
 }

--- a/packages/core-di/src/types.ts
+++ b/packages/core-di/src/types.ts
@@ -55,10 +55,10 @@ export type ServiceBuilderOptions<T extends SourceType> = {
 export type RegistrationMap<T extends SourceType = any> = Map<ServiceRegistration<T>, T>;
 export type DescriptorMap<T extends SourceType = any> = Map<ServiceIdentifier<T>, ServiceDescriptor<T>[]>;
 
-export const createRegistrationMap = <T extends SourceType = any>() => {
+export const createRegistrationMap = <T extends SourceType = any>(): RegistrationMap<T> => {
   return new Map<ServiceRegistration<T>, T>();
 };
 
-export const createDescriptorMap = <T extends SourceType = any>() => {
+export const createDescriptorMap = <T extends SourceType = any>(): DescriptorMap<T> => {
   return new Map<ServiceIdentifier<T>, ServiceDescriptor<T>[]>();
 };

--- a/packages/core-di/test/disposal.spec.ts
+++ b/packages/core-di/test/disposal.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { createServiceCollection, type IDisposable } from '../src';
+
+abstract class IDisposableService {
+  abstract get disposed(): boolean;
+}
+
+class DisposableService implements IDisposableService, IDisposable {
+  #disposed = false;
+  get disposed() {
+    return this.#disposed;
+  }
+  [Symbol.dispose]() {
+    this.#disposed = true;
+  }
+}
+
+describe('Disposal', () => {
+  describe('Singleton lifetime', () => {
+    it('does not dispose singleton when scoped provider is disposed', () => {
+      const services = createServiceCollection();
+      services.register(IDisposableService).to(DisposableService).singleton();
+      const provider = services.buildProvider();
+      const scoped = provider.createScope();
+
+      const instance = scoped.resolve(IDisposableService);
+      scoped[Symbol.dispose]();
+
+      expect(instance.disposed).toBe(false);
+    });
+
+    it('disposes singleton when root provider is disposed', () => {
+      const services = createServiceCollection();
+      services.register(IDisposableService).to(DisposableService).singleton();
+      const provider = services.buildProvider();
+
+      const instance = provider.resolve(IDisposableService);
+      provider[Symbol.dispose]();
+
+      expect(instance.disposed).toBe(true);
+    });
+  });
+
+  describe('Scoped lifetime', () => {
+    it('disposes scoped instance when scoped provider is disposed', () => {
+      const services = createServiceCollection();
+      services.register(IDisposableService).to(DisposableService).scoped();
+      const provider = services.buildProvider();
+      const scoped = provider.createScope();
+
+      const instance = scoped.resolve(IDisposableService);
+      scoped[Symbol.dispose]();
+
+      expect(instance.disposed).toBe(true);
+    });
+  });
+
+  describe('Transient lifetime', () => {
+    it('disposes transient instance when provider is disposed', () => {
+      const services = createServiceCollection();
+      services.register(IDisposableService).to(DisposableService).transient();
+      const provider = services.buildProvider();
+
+      const instance = provider.resolve(IDisposableService);
+      provider[Symbol.dispose]();
+
+      expect(instance.disposed).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Fix root provider to dispose singleton IDisposable instances on disposal, matching MS DI behaviour
- Add IDisposable implementation to IServiceProvider interface
- Refactor ServiceProvider to use private constructor with static createRoot factory
- Add 4 disposal lifecycle tests covering singleton, scoped, and transient lifetimes

Co-Authored-By: Claude <noreply@anthropic.com>